### PR TITLE
Use `ocm token` in `list` command to access OCM

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/charmbracelet/huh/spinner"
 	"github.com/geowa4/servicelogger/pkg/internalservicelog"
@@ -22,7 +21,7 @@ var internalServiceLogCmd = &cobra.Command{
 ` + "Example: `servicelogger internal -u 'https://api.openshift.com' -t \"$(ocm token)\" -c $CLUSTER_ID`",
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		cobra.CheckErr(validateArgs())
+		cobra.CheckErr(checkRequiredStringArgs("ocm_url", "ocm_token", "cluster_id"))
 		desc, confirmation, err := internalservicelog.Program()
 		cobra.CheckErr(err)
 		if confirmation {
@@ -44,27 +43,14 @@ var internalServiceLogCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(internalServiceLogCmd)
-
 	internalServiceLogCmd.Flags().StringP("ocm-url", "u", "https://api.openshift.com", "OCM URL (falls back to $OCM_URL and then 'https://api.openshift.com')")
 	_ = viper.BindPFlag("ocm_url", internalServiceLogCmd.Flags().Lookup("ocm-url"))
 	internalServiceLogCmd.Flags().StringP("ocm-token", "t", "", "OCM token (falls back to $OCM_TOKEN)")
 	_ = viper.BindPFlag("ocm_token", internalServiceLogCmd.Flags().Lookup("ocm-token"))
 	internalServiceLogCmd.Flags().StringP("cluster-id", "c", "", "internal cluster ID (defaults to $CLUSTER_ID)")
 	_ = viper.BindPFlag("cluster_id", internalServiceLogCmd.Flags().Lookup("cluster-id"))
-}
 
-func validateArgs() error {
-	if viper.GetString("ocm_url") == "" {
-		return errors.New("argument --ocm-url or environment variable $OCM_URL not set")
-	}
-	if viper.GetString("ocm_token") == "" {
-		return errors.New("argument --token or environment variable $OCM_TOKEN not set")
-	}
-	if viper.GetString("cluster_id") == "" {
-		return errors.New("argument --cluster-id or environment variable $CLUSTER_ID not set")
-	}
-	return nil
+	rootCmd.AddCommand(internalServiceLogCmd)
 }
 
 func sendServiceLog(url, token, clusterId, description string) error {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/spf13/viper"
 	"os"
 	"slices"
 
@@ -13,54 +16,57 @@ import (
 )
 
 var (
-	accessToken  string
-	refreshToken string
-	clusterID    string
-	listCmd      = &cobra.Command{
+	listCmd = &cobra.Command{
 		Use:   "list",
 		Short: "Display service logs",
 		Long: `Display a filterable list of service logs
 
 ` + "Example: `osdctl servicelog list $CLUSTER_ID | servicelogger list`",
 		Run: func(cmd *cobra.Command, args []string) {
-			serviceLogList := []ocm.ServiceLog{}
+			cobra.CheckErr(checkRequiredStringArgs("ocm_url", "ocm_token", "cluster_id"))
+			serviceLogList := make([]ocm.ServiceLog, 0)
 			var routineErr error
 			ctx, cancel := context.WithCancel(context.Background())
 			go func() {
 				defer cancel()
-				conn, err := ocm.NewConnection(accessToken, refreshToken)
+				conn, err := ocm.NewConnectionWithTemporaryToken(
+					viper.GetString("ocm_url"),
+					viper.GetString("ocm_token"),
+				)
 				if err != nil {
 					routineErr = fmt.Errorf("could not parse input: %v\n", err)
 					return
 				}
-				defer conn.Close()
+				defer func(conn *sdk.Connection) {
+					_ = conn.Close()
+				}(conn)
 				client := ocm.NewClient(conn)
-				serviceLogList, err = client.ListServiceLogs(clusterID, "")
+				serviceLogList, err = client.ListServiceLogs(viper.GetString("cluster_id"), "")
 				if err != nil {
 					routineErr = fmt.Errorf("could not get serviceLogs: %v\n", err)
 					return
 				}
 				if len(serviceLogList) == 0 {
-					routineErr = fmt.Errorf("no service logs to view")
+					routineErr = errors.New("no service logs to view")
 					return
 				}
 			}()
 
 			err := spinner.New().Title("loading service logs from ocm...").Context(ctx).Run()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "could not get servicelogs: %v", err)
-				os.Exit(0)
+				_, _ = fmt.Fprintf(os.Stderr, "could not get servicelogs: %v", err)
+				os.Exit(1)
 			}
 			if routineErr != nil {
-				fmt.Fprintf(os.Stderr, "could not get servicelogs: %v", err)
-				os.Exit(0)
+				_, _ = fmt.Fprintf(os.Stderr, "could not get servicelogs: %v", err)
+				os.Exit(1)
 			}
 
 			slices.Reverse(serviceLogList)
 			md, err := list.Program(serviceLogList)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "could not run bubble program: %v", err)
-				os.Exit(0)
+				_, _ = fmt.Fprintf(os.Stderr, "could not run bubble program: %v", err)
+				os.Exit(1)
 			}
 			fmt.Println(md)
 			os.Exit(0)
@@ -69,8 +75,11 @@ var (
 )
 
 func init() {
-	listCmd.Flags().StringVarP(&clusterID, "cluster-id", "c", "", "Internal Cluster ID")
-	listCmd.Flags().StringVarP(&accessToken, "access-token", "a", "", "Your OCM acccess token")
-	listCmd.Flags().StringVarP(&refreshToken, "refresh-token", "r", "", "Your OCM refresh token")
+	_ = viper.BindPFlag("ocm_url", listCmd.Flags().Lookup("ocm-url"))
+	listCmd.Flags().StringP("ocm-token", "t", "", "OCM token (falls back to $OCM_TOKEN)")
+	_ = viper.BindPFlag("ocm_token", listCmd.Flags().Lookup("ocm-token"))
+	listCmd.Flags().StringP("cluster-id", "c", "", "internal cluster ID (defaults to $CLUSTER_ID)")
+	_ = viper.BindPFlag("cluster_id", listCmd.Flags().Lookup("cluster-id"))
+
 	rootCmd.AddCommand(listCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/geowa4/servicelogger/pkg/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"strings"
 )
 
 var cfgFile string
@@ -53,4 +54,26 @@ func initConfig() {
 			cobra.CheckErr(fmt.Errorf("bad config file (%s): %q", viper.ConfigFileUsed(), err))
 		}
 	}
+}
+
+func checkRequiredStringArgs(args ...string) error {
+	for _, arg := range args {
+		if viper.GetString(arg) == "" {
+			return fmt.Errorf(
+				"argument --%s or environmnet variable %s not set",
+				arg,
+				strings.ToUpper(arg),
+			)
+		}
+	}
+	if viper.GetString("ocm_url") == "" {
+		return errors.New("argument --ocm-url or environment variable $OCM_URL not set")
+	}
+	if viper.GetString("ocm_token") == "" {
+		return errors.New("argument --token or environment variable $OCM_TOKEN not set")
+	}
+	if viper.GetString("cluster_id") == "" {
+		return errors.New("argument --cluster-id or environment variable $CLUSTER_ID not set")
+	}
+	return nil
 }

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -54,15 +54,6 @@ func NewConnectionWithTemporaryToken(url, token string) (*sdk.Connection, error)
 	return connection, nil
 }
 
-func NewConnection(accessToken, refreshToken string) (*sdk.Connection, error) {
-	connection, err := sdk.NewConnectionBuilder().Tokens(accessToken, refreshToken).Build()
-	if err != nil {
-		return nil, fmt.Errorf("error building ocm sdk connection :: %q \n", err)
-	}
-
-	return connection, nil
-}
-
 func (c Client) PostInternalServiceLog(clusterId string, description string) error {
 	logEntry, err := clv1.NewLogEntry().
 		InternalOnly(true).


### PR DESCRIPTION
Use the `ocm token` output to connect to the OCM API securely with a short-lived token. Default to `$OCM_TOKEN` environment variable.

closes #10