### PR TITLE
Move viper bindings to command pre-run property

### DIFF
--- a/cmd/cache_update.go
+++ b/cmd/cache_update.go
@@ -12,7 +12,7 @@ var cacheUpdateCmd = &cobra.Command{
 	Short: "Initialize or update the cached service log templates",
 	Long:  `Downloads the latest templates from openshift/managed-notifications into a local cache directory`,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		bindViper(cmd)
+		_ = viper.BindPFlag("cache_directory", cmd.Flags().Lookup("directory"))
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		templates.CacheManagedNotifications()
@@ -25,8 +25,4 @@ func init() {
 	cacheDir, err := config.GetDefaultCacheDir()
 	cobra.CheckErr(err)
 	cacheUpdateCmd.Flags().StringP("directory", "d", cacheDir, "Cache directory root")
-}
-
-func bindViper(cmd *cobra.Command) {
-	_ = viper.BindPFlag("cache_directory", cmd.Flags().Lookup("directory"))
 }

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -20,6 +20,11 @@ var internalServiceLogCmd = &cobra.Command{
 
 ` + "Example: `servicelogger internal -u 'https://api.openshift.com' -t \"$(ocm token)\" -c $CLUSTER_ID`",
 	Args: cobra.NoArgs,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		_ = viper.BindPFlag("ocm_url", cmd.Flags().Lookup("ocm-url"))
+		_ = viper.BindPFlag("ocm_token", cmd.Flags().Lookup("ocm-token"))
+		_ = viper.BindPFlag("cluster_id", cmd.Flags().Lookup("cluster-id"))
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		cobra.CheckErr(checkRequiredStringArgs("ocm_url", "ocm_token", "cluster_id"))
 		desc, confirmation, err := internalservicelog.Program()
@@ -45,11 +50,8 @@ var internalServiceLogCmd = &cobra.Command{
 
 func init() {
 	internalServiceLogCmd.Flags().StringP("ocm-url", "u", "https://api.openshift.com", "OCM URL (falls back to $OCM_URL and then 'https://api.openshift.com')")
-	_ = viper.BindPFlag("ocm_url", internalServiceLogCmd.Flags().Lookup("ocm-url"))
 	internalServiceLogCmd.Flags().StringP("ocm-token", "t", "", "OCM token (falls back to $OCM_TOKEN)")
-	_ = viper.BindPFlag("ocm_token", internalServiceLogCmd.Flags().Lookup("ocm-token"))
 	internalServiceLogCmd.Flags().StringP("cluster-id", "c", "", "internal cluster ID (defaults to $CLUSTER_ID)")
-	_ = viper.BindPFlag("cluster_id", internalServiceLogCmd.Flags().Lookup("cluster-id"))
 
 	rootCmd.AddCommand(internalServiceLogCmd)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -22,6 +22,12 @@ var (
 		Long: `Display a filterable list of service logs
 
 ` + "Example: `osdctl servicelog list $CLUSTER_ID | servicelogger list`",
+		Args: cobra.NoArgs,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			_ = viper.BindPFlag("ocm_url", cmd.Flags().Lookup("ocm-url"))
+			_ = viper.BindPFlag("ocm_token", cmd.Flags().Lookup("ocm-token"))
+			_ = viper.BindPFlag("cluster_id", cmd.Flags().Lookup("cluster-id"))
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			cobra.CheckErr(checkRequiredStringArgs("ocm_url", "ocm_token", "cluster_id"))
 			serviceLogList := make([]ocm.ServiceLog, 0)
@@ -75,11 +81,9 @@ var (
 )
 
 func init() {
-	_ = viper.BindPFlag("ocm_url", listCmd.Flags().Lookup("ocm-url"))
+	listCmd.Flags().StringP("ocm-url", "u", "https://api.openshift.com", "OCM URL (falls back to $OCM_URL and then 'https://api.openshift.com')")
 	listCmd.Flags().StringP("ocm-token", "t", "", "OCM token (falls back to $OCM_TOKEN)")
-	_ = viper.BindPFlag("ocm_token", listCmd.Flags().Lookup("ocm-token"))
 	listCmd.Flags().StringP("cluster-id", "c", "", "internal cluster ID (defaults to $CLUSTER_ID)")
-	_ = viper.BindPFlag("cluster_id", listCmd.Flags().Lookup("cluster-id"))
 
 	rootCmd.AddCommand(listCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,8 +60,8 @@ func checkRequiredStringArgs(args ...string) error {
 	for _, arg := range args {
 		if viper.GetString(arg) == "" {
 			return fmt.Errorf(
-				"argument --%s or environmnet variable %s not set",
-				arg,
+				"argument --%s or environment variable %s not set",
+				strings.ReplaceAll(arg, "_", "-"),
 				strings.ToUpper(arg),
 			)
 		}

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -24,6 +24,11 @@ var sendServiceLogCmd = &cobra.Command{
 
 ` + "Example: `servicelogger search | servicelogger send -u 'https://api.openshift.com' -t \"$(ocm token)\" -c $CLUSTER_ID`",
 	Args: cobra.NoArgs,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		_ = viper.BindPFlag("ocm_url", cmd.Flags().Lookup("ocm-url"))
+		_ = viper.BindPFlag("ocm_token", cmd.Flags().Lookup("ocm-token"))
+		_ = viper.BindPFlag("cluster_id", cmd.Flags().Lookup("cluster-id"))
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		cobra.CheckErr(checkRequiredStringArgs("ocm_url", "ocm_token", "cluster_id"))
 
@@ -63,11 +68,8 @@ var sendServiceLogCmd = &cobra.Command{
 
 func init() {
 	sendServiceLogCmd.Flags().StringP("ocm-url", "u", "https://api.openshift.com", "OCM URL (falls back to $OCM_URL and then 'https://api.openshift.com')")
-	_ = viper.BindPFlag("ocm_url", sendServiceLogCmd.Flags().Lookup("ocm-url"))
 	sendServiceLogCmd.Flags().StringP("ocm-token", "t", "", "OCM token (falls back to $OCM_TOKEN)")
-	_ = viper.BindPFlag("ocm_token", sendServiceLogCmd.Flags().Lookup("ocm-token"))
 	sendServiceLogCmd.Flags().StringP("cluster-id", "c", "", "internal cluster ID (defaults to $CLUSTER_ID)")
-	_ = viper.BindPFlag("cluster_id", sendServiceLogCmd.Flags().Lookup("cluster-id"))
 
 	rootCmd.AddCommand(sendServiceLogCmd)
 }


### PR DESCRIPTION
On application start up (every time a command is called), every file's `init` function is executed. Because of this, any subsequent calls to `viper.BindPFlag` with the same key parameter will overwrite prior calls. We can work around this by only binding to viper directly before a command is run.