### PR TITLE
Allow sending to multiple clusters at once

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -26,7 +26,7 @@ var internalServiceLogCmd = &cobra.Command{
 		_ = viper.BindPFlag("cluster_id", cmd.Flags().Lookup("cluster-id"))
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		cobra.CheckErr(checkRequiredStringArgs("ocm_url", "ocm_token", "cluster_id"))
+		cobra.CheckErr(checkRequiredArgsExist("ocm_url", "ocm_token", "cluster_id"))
 		desc, confirmation, err := internalservicelog.Program()
 		cobra.CheckErr(err)
 		if confirmation {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -29,7 +29,7 @@ var (
 			_ = viper.BindPFlag("cluster_id", cmd.Flags().Lookup("cluster-id"))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			cobra.CheckErr(checkRequiredStringArgs("ocm_url", "ocm_token", "cluster_id"))
+			cobra.CheckErr(checkRequiredArgsExist("ocm_url", "ocm_token", "cluster_id"))
 			serviceLogList := make([]ocm.ServiceLog, 0)
 			var routineErr error
 			ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,9 +56,9 @@ func initConfig() {
 	}
 }
 
-func checkRequiredStringArgs(args ...string) error {
+func checkRequiredArgsExist(args ...string) error {
 	for _, arg := range args {
-		if viper.GetString(arg) == "" {
+		if !viper.IsSet(arg) {
 			return fmt.Errorf(
 				"argument --%s or environment variable %s not set",
 				strings.ReplaceAll(arg, "_", "-"),

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/viper"
 	"io"
 	"os"
-	"time"
+	"sync"
 )
 
 var sendServiceLogCmd = &cobra.Command{
@@ -22,15 +22,19 @@ var sendServiceLogCmd = &cobra.Command{
 	Short: "Send a service log",
 	Long: `Send service log to the customer from JSON template passed via stdin
 
-` + "Example: `servicelogger search | servicelogger send -u 'https://api.openshift.com' -t \"$(ocm token)\" -c $CLUSTER_ID`",
+Example: servicelogger search | servicelogger send -u 'https://api.openshift.com' -t \"$(ocm token)\" -c $CLUSTER_ID"`,
 	Args: cobra.NoArgs,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		_ = viper.BindPFlag("ocm_url", cmd.Flags().Lookup("ocm-url"))
 		_ = viper.BindPFlag("ocm_token", cmd.Flags().Lookup("ocm-token"))
 		_ = viper.BindPFlag("cluster_id", cmd.Flags().Lookup("cluster-id"))
+		_ = viper.BindPFlag("cluster_ids", cmd.Flags().Lookup("cluster-ids"))
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		cobra.CheckErr(checkRequiredStringArgs("ocm_url", "ocm_token", "cluster_id"))
+		if !viper.IsSet("cluster_ids") {
+			viper.Set("cluster_ids", []string{viper.GetString("cluster_id")})
+		}
+		cobra.CheckErr(checkRequiredArgsExist("ocm_url", "ocm_token", "cluster_ids"))
 
 		var template templates.Template
 		input, err := io.ReadAll(os.Stdin)
@@ -39,27 +43,48 @@ var sendServiceLogCmd = &cobra.Command{
 		cobra.CheckErr(err)
 		fmt.Println(teaspoon.RenderMarkdown(template.String()))
 
+		clusterIds := viper.GetStringSlice("cluster_ids")
 		confirmation := false
-		err = huh.NewForm(huh.NewGroup(huh.NewConfirm().Value(&confirmation).Title("Send this service log?").Affirmative("Send").Negative("Cancel"))).Run()
+		err = huh.NewForm(huh.NewGroup(huh.NewConfirm().Value(&confirmation).Title(fmt.Sprintf("Send this service log to %v cluster(s)?", len(clusterIds))).Affirmative("Send").Negative("Cancel"))).Run()
 		if err != nil {
 			return
 		}
 
 		if confirmation {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			var errSendSL error
+			ctx, cancel := context.WithCancel(context.Background())
+			var serviceLogWaitGroup sync.WaitGroup
+			for _, clusterId := range clusterIds {
+				serviceLogWaitGroup.Add(1)
+				go func(cId string) {
+					defer serviceLogWaitGroup.Done()
+
+					errSendSL := sendServiceLog(
+						viper.GetString("ocm_url"),
+						viper.GetString("ocm_token"),
+						cId,
+						template,
+					)
+
+					result := fmt.Sprintf("%s\t", cId)
+					if errSendSL == nil {
+						result += "success"
+					} else {
+						result += fmt.Sprintf("failure\t%v", errSendSL.Error())
+					}
+
+					fmt.Println(result)
+				}(clusterId)
+			}
+
+			done := make(chan bool)
 			go func() {
-				defer cancel()
-				errSendSL = sendServiceLog(
-					viper.GetString("ocm_url"),
-					viper.GetString("ocm_token"),
-					viper.GetString("cluster_id"),
-					template)
+				_ = spinner.New().Title("Sending service log").Context(ctx).Run()
+				done <- true
 			}()
-			err = spinner.New().Title("Sending service log").Context(ctx).Run()
-			cobra.CheckErr(errSendSL)
-			cobra.CheckErr(err)
-			_, _ = fmt.Fprint(os.Stderr, "Service log sent")
+
+			serviceLogWaitGroup.Wait()
+			cancel()
+			<-done
 		} else {
 			_, _ = fmt.Fprint(os.Stderr, "Service log canceled")
 		}
@@ -70,6 +95,9 @@ func init() {
 	sendServiceLogCmd.Flags().StringP("ocm-url", "u", "https://api.openshift.com", "OCM URL (falls back to $OCM_URL and then 'https://api.openshift.com')")
 	sendServiceLogCmd.Flags().StringP("ocm-token", "t", "", "OCM token (falls back to $OCM_TOKEN)")
 	sendServiceLogCmd.Flags().StringP("cluster-id", "c", "", "internal cluster ID (defaults to $CLUSTER_ID)")
+	sendServiceLogCmd.Flags().StringSlice("cluster-ids", nil, "internal cluster IDs (defaults to $CLUSTER_IDS, space separated)")
+
+	sendServiceLogCmd.MarkFlagsMutuallyExclusive("cluster-id", "cluster-ids")
 
 	rootCmd.AddCommand(sendServiceLogCmd)
 }


### PR DESCRIPTION
Allow for sending an SL to multiple clusters simultaneously. The command will print out which clusters succeeded and which failed (with error message) in real time as each thread completes.

Resolves https://github.com/geowa4/servicelogger/issues/12