### PR TITLE
Send internal SL to multiple clusters

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -1,16 +1,9 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
-	"github.com/charmbracelet/huh/spinner"
 	"github.com/geowa4/servicelogger/pkg/internalservicelog"
-	"github.com/geowa4/servicelogger/pkg/ocm"
-	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"time"
 )
 
 var internalServiceLogCmd = &cobra.Command{
@@ -21,50 +14,31 @@ var internalServiceLogCmd = &cobra.Command{
 ` + "Example: `servicelogger internal -u 'https://api.openshift.com' -t \"$(ocm token)\" -c $CLUSTER_ID`",
 	Args: cobra.NoArgs,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		_ = viper.BindPFlag("ocm_url", cmd.Flags().Lookup("ocm-url"))
-		_ = viper.BindPFlag("ocm_token", cmd.Flags().Lookup("ocm-token"))
-		_ = viper.BindPFlag("cluster_id", cmd.Flags().Lookup("cluster-id"))
+		bindSendArgsToViper(cmd)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		cobra.CheckErr(checkRequiredArgsExist("ocm_url", "ocm_token", "cluster_id"))
+		if !viper.IsSet("cluster_ids") {
+			viper.Set("cluster_ids", []string{viper.GetString("cluster_id")})
+		}
+		cobra.CheckErr(checkRequiredArgsExist("ocm_url", "ocm_token", "cluster_ids"))
+
 		desc, confirmation, err := internalservicelog.Program()
 		cobra.CheckErr(err)
+
 		if confirmation {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			var errSendSL error
-			go func() {
-				defer cancel()
-				errSendSL = sendInternalServiceLog(
+			sendServiceLogsToManyClusters(viper.GetStringSlice("cluster_ids"), func(cId string) error {
+				return sendInternalServiceLog(
 					viper.GetString("ocm_url"),
 					viper.GetString("ocm_token"),
-					viper.GetString("cluster_id"),
-					desc)
-			}()
-			err = spinner.New().Title("Sending service log").Context(ctx).Run()
-			cobra.CheckErr(errSendSL)
-			cobra.CheckErr(err)
-			_, _ = fmt.Fprint(os.Stderr, "Service log sent")
+					cId,
+					desc,
+				)
+			})
 		}
 	},
 }
 
 func init() {
-	internalServiceLogCmd.Flags().StringP("ocm-url", "u", "https://api.openshift.com", "OCM URL (falls back to $OCM_URL and then 'https://api.openshift.com')")
-	internalServiceLogCmd.Flags().StringP("ocm-token", "t", "", "OCM token (falls back to $OCM_TOKEN)")
-	internalServiceLogCmd.Flags().StringP("cluster-id", "c", "", "internal cluster ID (defaults to $CLUSTER_ID)")
-
+	setSendArgsOnCmd(internalServiceLogCmd)
 	rootCmd.AddCommand(internalServiceLogCmd)
-}
-
-func sendInternalServiceLog(url, token, clusterId, description string) error {
-	conn, err := ocm.NewConnectionWithTemporaryToken(url, token)
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error creating ocm connection: %q", err)
-	}
-	defer func(conn *sdk.Connection) {
-		_ = conn.Close()
-	}(conn)
-	client := ocm.NewClient(conn)
-	err = client.PostInternalServiceLog(clusterId, description)
-	return err
 }

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -1,20 +1,15 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/charmbracelet/huh"
-	"github.com/charmbracelet/huh/spinner"
-	"github.com/geowa4/servicelogger/pkg/ocm"
 	"github.com/geowa4/servicelogger/pkg/teaspoon"
 	"github.com/geowa4/servicelogger/pkg/templates"
-	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"io"
 	"os"
-	"sync"
 )
 
 var sendServiceLogCmd = &cobra.Command{
@@ -25,10 +20,7 @@ var sendServiceLogCmd = &cobra.Command{
 Example: servicelogger search | servicelogger send -u 'https://api.openshift.com' -t \"$(ocm token)\" -c $CLUSTER_ID"`,
 	Args: cobra.NoArgs,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		_ = viper.BindPFlag("ocm_url", cmd.Flags().Lookup("ocm-url"))
-		_ = viper.BindPFlag("ocm_token", cmd.Flags().Lookup("ocm-token"))
-		_ = viper.BindPFlag("cluster_id", cmd.Flags().Lookup("cluster-id"))
-		_ = viper.BindPFlag("cluster_ids", cmd.Flags().Lookup("cluster-ids"))
+		bindSendArgsToViper(cmd)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if !viper.IsSet("cluster_ids") {
@@ -46,45 +38,17 @@ Example: servicelogger search | servicelogger send -u 'https://api.openshift.com
 		clusterIds := viper.GetStringSlice("cluster_ids")
 		confirmation := false
 		err = huh.NewForm(huh.NewGroup(huh.NewConfirm().Value(&confirmation).Title(fmt.Sprintf("Send this service log to %v cluster(s)?", len(clusterIds))).Affirmative("Send").Negative("Cancel"))).Run()
-		if err != nil {
-			return
-		}
+		cobra.CheckErr(err)
 
 		if confirmation {
-			ctx, cancel := context.WithCancel(context.Background())
-			var serviceLogWaitGroup sync.WaitGroup
-			for _, clusterId := range clusterIds {
-				serviceLogWaitGroup.Add(1)
-				go func(cId string) {
-					defer serviceLogWaitGroup.Done()
-
-					errSendSL := sendServiceLog(
-						viper.GetString("ocm_url"),
-						viper.GetString("ocm_token"),
-						cId,
-						template,
-					)
-
-					result := fmt.Sprintf("%s\t", cId)
-					if errSendSL == nil {
-						result += "success"
-					} else {
-						result += fmt.Sprintf("failure\t%v", errSendSL.Error())
-					}
-
-					fmt.Println(result)
-				}(clusterId)
-			}
-
-			done := make(chan bool)
-			go func() {
-				_ = spinner.New().Title("Sending service log").Context(ctx).Run()
-				done <- true
-			}()
-
-			serviceLogWaitGroup.Wait()
-			cancel()
-			<-done
+			sendServiceLogsToManyClusters(viper.GetStringSlice("cluster_ids"), func(cId string) error {
+				return sendServiceLog(
+					viper.GetString("ocm_url"),
+					viper.GetString("ocm_token"),
+					cId,
+					template,
+				)
+			})
 		} else {
 			_, _ = fmt.Fprint(os.Stderr, "Service log canceled")
 		}
@@ -92,25 +56,6 @@ Example: servicelogger search | servicelogger send -u 'https://api.openshift.com
 }
 
 func init() {
-	sendServiceLogCmd.Flags().StringP("ocm-url", "u", "https://api.openshift.com", "OCM URL (falls back to $OCM_URL and then 'https://api.openshift.com')")
-	sendServiceLogCmd.Flags().StringP("ocm-token", "t", "", "OCM token (falls back to $OCM_TOKEN)")
-	sendServiceLogCmd.Flags().StringP("cluster-id", "c", "", "internal cluster ID (defaults to $CLUSTER_ID)")
-	sendServiceLogCmd.Flags().StringSlice("cluster-ids", nil, "internal cluster IDs (defaults to $CLUSTER_IDS, space separated)")
-
-	sendServiceLogCmd.MarkFlagsMutuallyExclusive("cluster-id", "cluster-ids")
-
+	setSendArgsOnCmd(sendServiceLogCmd)
 	rootCmd.AddCommand(sendServiceLogCmd)
-}
-
-func sendServiceLog(url, token, clusterId string, t templates.Template) error {
-	conn, err := ocm.NewConnectionWithTemporaryToken(url, token)
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error creating ocm connection: %q", err)
-	}
-	defer func(conn *sdk.Connection) {
-		_ = conn.Close()
-	}(conn)
-	client := ocm.NewClient(conn)
-	err = client.PostServiceLog(clusterId, t)
-	return err
 }

--- a/cmd/sendutils.go
+++ b/cmd/sendutils.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/geowa4/servicelogger/pkg/ocm"
+	"github.com/geowa4/servicelogger/pkg/templates"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"os"
+	"sync"
+)
+
+func setSendArgsOnCmd(cmd *cobra.Command) {
+	cmd.Flags().StringP("ocm-url", "u", "https://api.openshift.com", "OCM URL (falls back to $OCM_URL and then 'https://api.openshift.com')")
+	cmd.Flags().StringP("ocm-token", "t", "", "OCM token (falls back to $OCM_TOKEN)")
+	cmd.Flags().StringP("cluster-id", "c", "", "internal cluster ID (defaults to $CLUSTER_ID)")
+	cmd.Flags().StringSlice("cluster-ids", nil, "internal cluster IDs (defaults to $CLUSTER_IDS, space separated)")
+
+	cmd.MarkFlagsMutuallyExclusive("cluster-id", "cluster-ids")
+}
+
+func bindSendArgsToViper(cmd *cobra.Command) {
+	_ = viper.BindPFlag("ocm_url", cmd.Flags().Lookup("ocm-url"))
+	_ = viper.BindPFlag("ocm_token", cmd.Flags().Lookup("ocm-token"))
+	_ = viper.BindPFlag("cluster_id", cmd.Flags().Lookup("cluster-id"))
+	_ = viper.BindPFlag("cluster_ids", cmd.Flags().Lookup("cluster-ids"))
+}
+
+func sendServiceLogsToManyClusters(clusterIds []string, sendFunc func(cId string) error) {
+	var serviceLogWaitGroup sync.WaitGroup
+	var printMutex sync.Mutex
+
+	for _, clusterId := range clusterIds {
+		serviceLogWaitGroup.Add(1)
+		go func(cId string) {
+			defer serviceLogWaitGroup.Done()
+
+			errSendSl := sendFunc(cId)
+
+			result := fmt.Sprintf("%s\t", cId)
+			if errSendSl == nil {
+				result += "success"
+			} else {
+				result += fmt.Sprintf("failure\t%v", errSendSl.Error())
+			}
+
+			printMutex.Lock()
+			defer printMutex.Unlock()
+			fmt.Println(result)
+		}(clusterId)
+	}
+
+	serviceLogWaitGroup.Wait()
+}
+
+func sendServiceLog(url, token, clusterId string, t templates.Template) error {
+	conn, err := ocm.NewConnectionWithTemporaryToken(url, token)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error creating ocm connection: %q", err)
+	}
+	defer func(conn *sdk.Connection) {
+		_ = conn.Close()
+	}(conn)
+	client := ocm.NewClient(conn)
+	err = client.PostServiceLog(clusterId, t)
+	return err
+}
+
+func sendInternalServiceLog(url, token, clusterId, description string) error {
+	conn, err := ocm.NewConnectionWithTemporaryToken(url, token)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error creating ocm connection: %q", err)
+	}
+	defer func(conn *sdk.Connection) {
+		_ = conn.Close()
+	}(conn)
+	client := ocm.NewClient(conn)
+	err = client.PostInternalServiceLog(clusterId, description)
+	return err
+}


### PR DESCRIPTION
Extracts the code added to the `send` command for this purpose into a reusable function that is now also consumed by the `internal` command.