### PR TITLE
Fixes search's filter function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 )
 
 require (
+	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
+github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -45,6 +47,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52 v1.0.3/go.mod h1:zT8H+Rk4VSabYN90pWyugflM3ZhpTZNC7cASDfUCdT4=
@@ -92,6 +95,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=

--- a/pkg/search/filter.go
+++ b/pkg/search/filter.go
@@ -1,0 +1,63 @@
+package search
+
+import (
+	"github.com/agnivade/levenshtein"
+	"github.com/charmbracelet/bubbles/list"
+	"math"
+	"slices"
+	"strings"
+)
+
+type Rank struct {
+	contains    bool
+	levenshtein int
+	rank        list.Rank
+}
+
+func FilterFunc(search string, templatesAsStrings []string) []list.Rank {
+	ranks := make([]Rank, 0)
+
+	for i, templateAsString := range templatesAsStrings {
+		r := Rank{
+			contains:    false,
+			levenshtein: math.MaxInt,
+			rank: list.Rank{
+				Index:          i,
+				MatchedIndexes: make([]int, 0), // used for underlining matched chars; meh
+			},
+		}
+		if strings.Contains(templateAsString, search) {
+			r.contains = true
+			r.levenshtein = 0
+		} else {
+			r.levenshtein = levenshtein.ComputeDistance(search, templateAsString)
+		}
+		if float64(len(search))/float64(len(templateAsString)) >= 0.1 &&
+			!r.contains &&
+			float64(r.levenshtein)/float64(len(templateAsString)) >= 0.75 {
+			// if the search text is sufficiently large and
+			// the search isn't present and
+			// the levenshtein distance is relatively large,
+			// it's not a match
+			continue
+		}
+		ranks = append(ranks, r)
+	}
+
+	// sort by whether the search text is contained by the template,
+	// followed by levenshtein distance
+	slices.SortFunc(ranks, func(a, b Rank) int {
+		if a.contains {
+			return -1
+		} else if b.contains {
+			return 1
+		}
+		return a.levenshtein - b.levenshtein
+	})
+
+	listRanks := make([]list.Rank, 0, len(ranks))
+	for _, r := range ranks {
+		listRanks = append(listRanks, r.rank)
+	}
+	return listRanks
+}

--- a/pkg/search/initialize.go
+++ b/pkg/search/initialize.go
@@ -38,6 +38,8 @@ func NewModel() *Model {
 	l.KeyMap.Quit.SetKeys("enter", "q")
 	l.KeyMap.Quit.SetHelp("enter/q", "select/quit")
 
+	l.Filter = FilterFunc
+
 	m := &Model{
 		allTemplates:      allTemplates,
 		templateSelection: allTemplates[0],


### PR DESCRIPTION
The built-in filter function used something built for searching for files. This allowed for fuzzy matches, which was why I switched to it, but it had weighted scoring that made no sense for this application. The custom filter function now prefers exact matches and then falls back to calculating Levenshtein distance. If the Levenshtein distance is too great after entering enough search text, the template is discarded.

Closes #24