### PR TITLE
Handle JSON parsing errors

### DIFF
--- a/pkg/templates/read.go
+++ b/pkg/templates/read.go
@@ -28,10 +28,9 @@ func WalkTemplates(processTemplate func(template *Template)) {
 		}
 		template := &Template{SourcePath: GetRelativePathForManagedNotifications(path)}
 		err = json.Unmarshal(fileBytes, template)
-		if err != nil {
-			return err
+		if err == nil {
+			processTemplate(template)
 		}
-		processTemplate(template)
 		return nil
 	})
 }


### PR DESCRIPTION
If the JSON of the template is bad, ignore it and keep parsing the rest.